### PR TITLE
Update msg.url

### DIFF
--- a/.defold_api/message.lua
+++ b/.defold_api/message.lua
@@ -44,7 +44,7 @@ function msg.url() end
 function msg.url(urlstring) end
 
 ---creates a new URL from separate arguments
----@param socket string|hash socket of the URL
+---@param socket string|hash|nil socket of the URL
 ---@param path string|hash path of the URL
 ---@param fragment string|hash fragment of the URL
 ---@return url a new URL


### PR DESCRIPTION
The argument "socket" can be nil.

https://defold.com/manuals/addressing/#urls

> You almost never need to specify the socket,